### PR TITLE
Fix get_quck_bar_slot offset

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -6,7 +6,7 @@ function define_quick_craft (pre, num, count_fn)
             return
         end
 
-        local slot = player.get_quick_bar_slot(num + 10 * page)
+        local slot = player.get_quick_bar_slot(num + 10 * (page - 1))
         if slot ~= null and slot.valid then
             try_craft(player, slot, count_fn)
         end

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "crafting-belt",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "title": "Crafting Belt",
     "author": "Frizi",
     "contact": "",


### PR DESCRIPTION
`get_active_quick_bar_page()` is in the range [1,10], but` get_quick_bar_slot()` expects a slot in the range of [0, 100].